### PR TITLE
Post-CI hardening: pre-commit, coverage, security audit, PyPI publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [master]
+    tags: ["v*"]
   pull_request:
     branches: [master]
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -84,8 +88,8 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: [build, security]
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -95,4 +99,4 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1


### PR DESCRIPTION
## Summary

- **Pre-commit hooks**: ruff linter + standard hooks (trailing whitespace, YAML check, large file guard)
- **CI workflow**: pip caching, 65% coverage threshold, `pip-audit` security job, build artifact upload
- **PyPI publish job**: trusted publisher (OIDC) on push to master — no secret tokens needed
- **Code quality**: ruff fixes across 20+ source/test files
- **Project hygiene**: MIT LICENSE, CONTRIBUTING.md, config/.env.example, ruff.toml

## Test plan

- [ ] Verify CI passes on this PR (lint, test, coverage, security, build jobs)
- [ ] After merge: configure PyPI trusted publishing in GitHub repo settings (see PR description below)
- [ ] Run `pre-commit run --all-files` locally to verify hooks work

## PyPI Trusted Publishing Setup

After merging, to enable the publish job:
1. Go to https://pypi.org/manage/account/publishing/
2. Add a new "pending publisher" (if package doesn't exist yet) or go to your package settings
3. Set: **Owner** = `Suyash2013`, **Repository** = `codebase-rag-mcp`, **Workflow** = `ci.yml`, **Environment** = `pypi`
4. In GitHub repo → Settings → Environments → create `pypi` environment (optionally add required reviewers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)