### PR TITLE
fix: resolve critical ONNX bugs, checkpoint persistence, and activate Gemini triage

### DIFF
--- a/docs/gemini-setup.md
+++ b/docs/gemini-setup.md
@@ -1,0 +1,40 @@
+# Gemini Workflow Setup
+
+The Gemini-powered triage and review workflows use the direct Gemini API (no GCP project or Workload Identity Federation required).
+
+## Required Secret
+
+| Secret | Description |
+|--------|-------------|
+| `GEMINI_API_KEY` | Gemini API key from [Google AI Studio](https://aistudio.google.com/app/apikey) |
+
+This secret is already configured in the repository. If you're forking, add it via **Settings → Secrets and variables → Actions → New repository secret**.
+
+## Required Variables
+
+Set the following via the GitHub CLI (run once per repository):
+
+```bash
+gh variable set GOOGLE_GENAI_USE_VERTEXAI --body "false"
+gh variable set GOOGLE_GENAI_USE_GCA --body "false"
+gh variable set GEMINI_MODEL --body "gemini-3.1-pro-preview"
+gh variable set GEMINI_CLI_VERSION --body "latest"
+gh variable set GEMINI_DEBUG --body "false"
+```
+
+Or set them via **Settings → Secrets and variables → Actions → Variables**.
+
+## What These Enable
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `gemini-triage.yml` | `issues.opened` | Auto-labels and summarises new issues |
+| `gemini-scheduled-triage.yml` | Hourly cron | Picks up any unlabeled issues |
+| `gemini-review.yml` | PR opened/updated | AI code review on pull requests |
+| `gemini-dispatch.yml` | `@gemini` mention in issues/PRs | On-demand Gemini assistance |
+
+## Notes
+
+- `GOOGLE_GENAI_USE_VERTEXAI=false` and `GOOGLE_GENAI_USE_GCA=false` tell the Gemini CLI to authenticate via `GEMINI_API_KEY` instead of GCP service account credentials.
+- No `APP_ID` or `APP_PRIVATE_KEY` is required — workflows fall back to `GITHUB_TOKEN` for repo operations.
+- The `gemini-3.1-pro-preview` model is used by default. To change it, update the `GEMINI_MODEL` variable.

--- a/mcp_server/embeddings/onnx_local.py
+++ b/mcp_server/embeddings/onnx_local.py
@@ -102,16 +102,17 @@ class OnnxLocalProvider(EmbeddingProvider):
         tokenizer_file = Path(model_path) / "tokenizer.json"
 
         if not tokenizer_file.exists():
+            self._load_failed = True
             raise RuntimeError(f"Tokenizer not found at {tokenizer_file}")
 
         try:
             self._session = ort.InferenceSession(str(onnx_file))
+            self._tokenizer = Tokenizer.from_file(str(tokenizer_file))
+            self._tokenizer.enable_truncation(max_length=512)
+            self._tokenizer.enable_padding(length=512)
         except Exception:
             self._load_failed = True
             raise
-        self._tokenizer = Tokenizer.from_file(str(tokenizer_file))
-        self._tokenizer.enable_truncation(max_length=512)
-        self._tokenizer.enable_padding(length=512)
 
         info = _MODEL_REGISTRY.get(model_name, {})
         self._dimension = info.get("dimension", 384)  # type: ignore[assignment]

--- a/mcp_server/embeddings/onnx_local.py
+++ b/mcp_server/embeddings/onnx_local.py
@@ -21,7 +21,7 @@ _MODEL_REGISTRY = {
 def _download_model(model_name: str, model_dir: str) -> str:
     """Download ONNX model from HuggingFace Hub if not cached. Returns model directory path."""
     model_path = Path(model_dir) / model_name
-    onnx_path = model_path / "model.onnx"
+    onnx_path = model_path / "onnx" / "model.onnx"
 
     if onnx_path.exists():
         return str(model_path)
@@ -41,7 +41,7 @@ def _download_model(model_name: str, model_dir: str) -> str:
         snapshot_download(
             repo_id=str(info["repo_id"]),
             local_dir=str(model_path),
-            allow_patterns=["*.onnx", "*.json", "*.txt", "tokenizer*"],
+            allow_patterns=["onnx/model.onnx", "*.json", "*.txt", "tokenizer*"],
         )
     except ImportError:
         raise RuntimeError(
@@ -68,32 +68,47 @@ class OnnxLocalProvider(EmbeddingProvider):
         self._session: Any = None
         self._tokenizer: Any = None
         self._dimension: int | None = None
+        self._load_failed: bool = False
 
     def _ensure_loaded(self) -> None:
         if self._session is not None:
             return
+        if self._load_failed:
+            raise RuntimeError(
+                "ONNX model failed to load on a previous attempt. "
+                "Check logs for the original error."
+            )
 
         model_dir = settings.get_onnx_model_path()
         model_name = settings.onnx_model_name
 
-        model_path = _download_model(model_name, model_dir)
+        try:
+            model_path = _download_model(model_name, model_dir)
+        except Exception:
+            self._load_failed = True
+            raise
 
         try:
             import onnxruntime as ort
             from tokenizers import Tokenizer
         except ImportError as e:
+            self._load_failed = True
             raise RuntimeError(
                 f"ONNX provider requires onnxruntime and tokenizers. "
                 f"Install with: pip install onnxruntime tokenizers. Error: {e}"
             ) from e
 
-        onnx_file = Path(model_path) / "model.onnx"
+        onnx_file = Path(model_path) / "onnx" / "model.onnx"
         tokenizer_file = Path(model_path) / "tokenizer.json"
 
         if not tokenizer_file.exists():
             raise RuntimeError(f"Tokenizer not found at {tokenizer_file}")
 
-        self._session = ort.InferenceSession(str(onnx_file))
+        try:
+            self._session = ort.InferenceSession(str(onnx_file))
+        except Exception:
+            self._load_failed = True
+            raise
         self._tokenizer = Tokenizer.from_file(str(tokenizer_file))
         self._tokenizer.enable_truncation(max_length=512)
         self._tokenizer.enable_padding(length=512)

--- a/mcp_server/ingestion.py
+++ b/mcp_server/ingestion.py
@@ -228,13 +228,17 @@ def ingest_directory(
 
     elapsed = time.time() - start_time
 
-    # Save checkpoint if we didn't hit the timeout.
-    # Use elapsed time, not file count — individual file failures are logged
-    # as warnings and should not prevent the checkpoint from being saved.
+    # Save checkpoint if we didn't hit the timeout and at least some files
+    # were processed. A systemic failure (e.g. ONNX model fails to load)
+    # causes all files to fail quickly — saving the checkpoint in that case
+    # would mark all files as "done" and skip them on the next incremental run.
     timed_out = elapsed >= timeout_seconds
-    if not timed_out:
+    system_failure = len(processed_files) == 0 and len(files_to_ingest) > 0
+    if not timed_out and not system_failure:
         detector = create_detector(directory)
         detector.save_checkpoint(directory)
+    elif system_failure:
+        log.error("All files failed to process. Checkpoint NOT saved.")
     else:
         log.warning("Ingestion timed out after %.1fs. Checkpoint NOT saved.", elapsed)
 
@@ -346,9 +350,12 @@ def ingest_incremental(
     else:
         msg = "No chunks generated from changed files"
 
-    # Save checkpoint if we didn't hit the timeout.
+    # Save checkpoint if we didn't hit the timeout and at least some files
+    # were processed. A systemic failure skips saving to avoid marking
+    # failed files as successfully indexed.
     elapsed = time.time() - start_time
-    if elapsed < timeout_seconds:
+    system_failure = len(processed) == 0 and len(files_to_ingest) > 0
+    if elapsed < timeout_seconds and not system_failure:
         detector.save_checkpoint(directory)
 
     return msg

--- a/mcp_server/ingestion.py
+++ b/mcp_server/ingestion.py
@@ -228,13 +228,15 @@ def ingest_directory(
 
     elapsed = time.time() - start_time
 
-    # Save checkpoint if no timeout
-    timed_out = len(processed_files) < len(files_to_ingest)
+    # Save checkpoint if we didn't hit the timeout.
+    # Use elapsed time, not file count — individual file failures are logged
+    # as warnings and should not prevent the checkpoint from being saved.
+    timed_out = elapsed >= timeout_seconds
     if not timed_out:
         detector = create_detector(directory)
         detector.save_checkpoint(directory)
     else:
-        log.warning("Ingestion incomplete. Checkpoint NOT saved.")
+        log.warning("Ingestion timed out after %.1fs. Checkpoint NOT saved.", elapsed)
 
     msg = f"Ingested {count} chunks from {len(processed_files)}/{len(files_to_ingest)} files ({elapsed:.1f}s)"
     log.info(msg)
@@ -344,8 +346,9 @@ def ingest_incremental(
     else:
         msg = "No chunks generated from changed files"
 
-    # Save checkpoint
-    if len(processed) == len(files_to_ingest):
+    # Save checkpoint if we didn't hit the timeout.
+    elapsed = time.time() - start_time
+    if elapsed < timeout_seconds:
         detector.save_checkpoint(directory)
 
     return msg

--- a/mcp_server/tools/structure.py
+++ b/mcp_server/tools/structure.py
@@ -12,8 +12,8 @@ from mcp_server.analysis.structure import (
 # Directories to skip — driven by settings.skip_directories
 
 
-def get_file_signatures(file_pattern: str = "") -> str:
-    """Get function and class signatures from files matching a pattern.
+def get_file_signatures(file_path: str = "") -> str:
+    """Get function and class signatures from files matching a path.
 
     Use this to understand the API surface of a module without reading
     every file. Returns function names, parameters, return types, and
@@ -23,9 +23,9 @@ def get_file_signatures(file_pattern: str = "") -> str:
     of code modules.
 
     Args:
-        file_pattern: Substring to match in file paths (case-insensitive).
-                      E.g. "models", "api/routes", ".py", "utils".
-                      Empty string matches all files.
+        file_path: Substring to match in file paths (case-insensitive).
+                   E.g. "models", "api/routes", ".py", "utils".
+                   Empty string matches all files.
     """
     directory = settings.get_working_directory()
 
@@ -40,7 +40,7 @@ def get_file_signatures(file_pattern: str = "") -> str:
                 fp = Path(root) / f
                 rel_path = str(fp.relative_to(base))
 
-                if file_pattern and file_pattern.lower() not in rel_path.lower():
+                if file_path and file_path.lower() not in rel_path.lower():
                     continue
 
                 sigs = extract_signatures(str(fp))
@@ -48,7 +48,7 @@ def get_file_signatures(file_pattern: str = "") -> str:
                     results.append({"file": rel_path, "signatures": sigs})
 
         if not results:
-            return f"No signatures found for pattern '{file_pattern}'"
+            return f"No signatures found for path '{file_path}'"
 
         return _format_signatures(results)
 


### PR DESCRIPTION
## Summary

- **#25 / #28 — ONNX model path mismatch (broken semantic search):** HuggingFace Hub stores the ONNX model at `onnx/model.onnx` inside the repo, not `model.onnx` at the root. Fixed the path in `_download_model` and `_ensure_loaded`, and updated `allow_patterns` to match.
- **#26 — O(n) download retry storm:** Added `_load_failed` flag to `OnnxLocalProvider` so a single model-load failure short-circuits all subsequent embed calls instead of re-attempting the full download for every file.
- **#29 — Incremental ingest checkpoint never saved:** The `timed_out` check used file counts — any file failure (e.g., from the ONNX bug) made it look like a timeout and skipped the checkpoint. Fixed to use actual elapsed time in both `ingest_directory` and `ingest_incremental`.
- **#27 — `file_path` parameter ignored in `get_file_signatures`:** Renamed `file_pattern` → `file_path` to match user expectations.
- **Gemini triage activated:** Added `docs/gemini-setup.md` and configured the five required GitHub variables (`GOOGLE_GENAI_USE_VERTEXAI=false`, `GOOGLE_GENAI_USE_GCA=false`, `GEMINI_MODEL=gemini-3.1-pro-preview`, `GEMINI_CLI_VERSION=latest`, `GEMINI_DEBUG=false`) so the Gemini triage workflows use the existing `GEMINI_API_KEY` secret directly.

## Issues closed

- Closes #25
- Closes #26
- Closes #27
- Closes #28 (symptom of #25/#26)
- Closes #29
- Previously closed (already fixed in codebase): #13, #14, #20

## Test plan

- [x] `python -m pytest tests/ -v` — 185/185 passing
- [ ] Fresh ingest: confirm `stats` shows `vectors_count > 0` after first run
- [ ] Incremental ingest: second run with no changes reports `Index is up to date` in <5s
- [ ] `get_file_signatures` with a specific path returns only matching file signatures
- [ ] Open a test issue → `gemini-triage.yml` fires and labels it automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)