### PR TITLE
chore: release prep 3.0.1 — bump version and add PyPI metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,21 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omni-rag-mcp"
-version = "3.0.0"
+version = "3.0.1"
 description = "General-purpose RAG MCP plugin — index anything, search with hybrid BM25+semantic, zero-config"
+readme = "README.md"
+license = { text = "MIT" }
 requires-python = ">=3.10"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 dependencies = [
     "mcp[cli]>=1.0.0",
     "qdrant-client>=1.9.0",
@@ -17,6 +29,11 @@ dependencies = [
     "tokenizers>=0.15.0",
     "huggingface-hub>=0.20.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/Suyash2013/codebase-rag-mcp"
+Repository = "https://github.com/Suyash2013/codebase-rag-mcp"
+Issues = "https://github.com/Suyash2013/codebase-rag-mcp/issues"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov", "responses", "ruff>=0.8.0", "mypy>=1.13.0", "pre-commit>=4.0"]


### PR DESCRIPTION
## Summary

- Bumps version `3.0.0` → `3.0.1`
- Adds `readme = "README.md"` so PyPI renders the package long description (closes #23)
- Adds `classifiers` for discoverability and trust signals on PyPI
- Adds `license` field
- Adds `[project.urls]` (Homepage, Repository, Issues)

## After merge

Tag master to trigger the release pipeline:
\`\`\`bash
git checkout master && git pull
git tag -a v3.0.1 -m "Release v3.0.1"
git push origin v3.0.1
\`\`\`
CI will then build, publish to PyPI, and create the GitHub Release automatically.

## Test plan

- [x] `python -m pytest tests/ -v` — all 185 tests pass
- [ ] Verify PyPI page renders README after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)